### PR TITLE
Add ORM models and REST API server

### DIFF
--- a/.flake8.ini
+++ b/.flake8.ini
@@ -1,7 +1,7 @@
 [flake8]
 show-source = True
 # E123, E125 seem invalid
-ignore = E123,E125,D104,D100,D101,D102,D103,D107,D412,W504
+ignore = E123,E125,D104,D100,D101,D102,D103,D106,D107,D412,W504
 enable-extensions=H106,H203,H204,H205,H210,H904
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build

--- a/docs/specs/softboxen-api.yml
+++ b/docs/specs/softboxen-api.yml
@@ -1,0 +1,988 @@
+openapi: 3.0.0
+info:
+  license:
+    name: BSD License
+  version: '1.0.0'
+  title: 'CLI Simulator REST API'
+  description: >
+
+servers:
+  - url: http://127.0.0.1:5000/softboxen/v1
+  - url: https://virtserver.swaggerhub.com/etingof/softboxen/1.0.0
+
+paths:
+  /boxen:
+    get:
+      description: >
+        This resource represents a list of all existing simulated
+        network devices.
+      summary: >
+        List all existing simulated network devices
+      parameters:
+        - name: vendor
+          in: query
+          description: >
+            Search boxen by vendor name
+          required: false
+          schema:
+            type: string
+        - name: model
+          in: query
+          description: >
+            Search boxen by model name
+          required: false
+          schema:
+            type: string
+        - name: version
+          in: query
+          description: >
+            Search boxen by version
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: >
+            An array of boxen
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Boxen"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a new simulated network device
+      requestBody:
+        description: >
+          Receive a new network device of specified type
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BoxRequired"
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}:
+    description: >
+      Represents a single simulated network device identified by `id`.
+    get:
+      summary: Get info for a specific simulated network device.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: >
+            The ID of the simulated network device information
+            to retrieve
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Box"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete simulated network device.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the simulated network device to delete.
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}/credentials:
+    description: >
+      This resource represents user credentials at the
+      simulated network device.
+    get:
+      summary: >
+        List all existing credentials
+      parameters:
+        - name: protocol
+          in: query
+          description: >
+            Search credential by authentication protocol type.
+          required: false
+          schema:
+            type: string
+            enum: ["password"]
+        - name: user
+          in: query
+          description: >
+            Search credential by user name
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: >
+            An array of user credentials.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Credentials"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create new user credentials.
+      requestBody:
+        description: >
+          New user credentials object.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CredentialRequired"
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}/credentials/{credential_id}:
+    description: >
+      This resource represents a single user credential information,
+      identified by `id`, as a simulated network device identified
+      by `box_id`.
+    get:
+      summary: Info for a specific credential entry.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: credential_id
+          in: path
+          required: true
+          description: The ID of the authentication information record.
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Credential"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete user credential record.
+      parameters:
+        - name: box_id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: id
+          in: path
+          required: true
+          description: The ID of the authentication information record.
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}/ports:
+    description: >
+      This resource represents network ports at the simulated network device.
+    get:
+      summary: >
+        List all existing ports
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: name
+          in: query
+          description: >
+            Search port by name.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: >
+            An array of network ports.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ports"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create new network port.
+      requestBody:
+        description: >
+          New network port object.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PortRequired"
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}/ports/{port_id}:
+    description: >
+      This resource represents a single network port information,
+      identified by `id`, as a simulated network device identified
+      by `box_id`.
+    get:
+      summary: Info for a specific port entry.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: port_id
+          in: path
+          required: true
+          description: The ID of the network port.
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Port"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete network port.
+      parameters:
+        - name: box_id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: id
+          in: path
+          required: true
+          description: The ID of the network port.
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}/ports/{port_id}/vlan_ports:
+    description: >
+      This resource represents VLAN ports at the network port of the
+      simulated network device.
+    get:
+      summary: >
+        List all existing VLAN ports
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: port_id
+          in: path
+          required: true
+          description: The ID of the network port.
+          schema:
+            type: integer
+        - name: name
+          in: query
+          description: >
+            Search VLAN port by name.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: >
+            An array of VLAN ports.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VlanPorts"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create new VLAN port.
+      requestBody:
+        description: >
+          New network VLAN port object.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VlanPortRequired"
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}/ports/{port_id}/vlan_ports/{vlan_port_id}:
+    description: >
+      This resource represents a single VLAN port object, identified by
+      `id` at the network port identified by `port_id` as the simulated
+      network device identified by `box_id`.
+    get:
+      summary: Get VLAN port information.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: port_id
+          in: path
+          required: true
+          description: The ID of the physical port at the simulated
+            network device.
+          schema:
+            type: integer
+        - name: vlan_port_id
+          in: path
+          required: true
+          description: The ID of the VLAN port.
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VlanPort"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete VLAN port.
+      parameters:
+        - name: box_id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: port_id
+          in: path
+          required: true
+          description: The ID of the physical port at the simulated
+            network device.
+          schema:
+            type: integer
+        - name: id
+          in: path
+          required: true
+          description: The ID of the VLAN port.
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}/routes:
+    description: >
+      This resource represents network routes at the simulated network device.
+    get:
+      summary: >
+        List all existing routes
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: >
+            The ID of the simulated network device information
+            to retrieve
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >
+            An array of network routes.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Routes"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create new network route.
+      requestBody:
+        description: >
+          New network route object.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RouteRequired"
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /boxen/{id}/routes/{route_id}:
+    description: >
+      This resource represents a single network route information,
+      identified by `id`, as a simulated network device identified
+      by `box_id`.
+    get:
+      summary: Info for a specific route entry.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: route_id
+          in: path
+          required: true
+          description: The ID of the network route.
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Route"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete network route.
+      parameters:
+        - name: box_id
+          in: path
+          required: true
+          description: The ID of the simulated network device.
+          schema:
+            type: integer
+        - name: id
+          in: path
+          required: true
+          description: The ID of the network route.
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    BoxRequired:
+      description: >
+        Required fields of simulated network device object.
+      type: object
+      required:
+        - vendor
+        - model
+        - version
+      properties:
+        vendor:
+          type: string
+        model:
+          type: string
+        version:
+          type: string
+
+    BoxOptional:
+      description: >
+        Optional fields of simulated network device object.
+      type: object
+      properties:
+        id:
+          description: >
+            Simulated network device unique ID.
+          type: integer
+          format: int64
+        uuid:
+          description: >
+            Simulated network device UUID.
+          type: string
+        description:
+          description: >
+            Descriptive name of this network device.
+          type: string
+        hostname:
+          description: >
+            Hostname assigned to this simulated network device.
+          type: string
+        mgmt_address:
+          description: >
+            Management network address to access this simulated network device.
+          type: string
+        credentials:
+          description: >
+            List of links to user access credentials.
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              _links:
+                $ref: "#/components/schemas/Links"
+        ports:
+          description: >
+            List of links to network ports that this network device has.
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              _links:
+                $ref: "#/components/schemas/Links"
+        routes:
+          description: >
+            List of links to network routes that this network device has.
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              _links:
+                $ref: "#/components/schemas/Links"
+
+    Box:
+      description: >
+        Simulated network device object.
+      allOf:
+        - $ref: "#/components/schemas/BoxRequired"
+        - $ref: "#/components/schemas/BoxOptional"
+
+    Boxen:
+      description: >
+        Collection of simulated network devices.
+      type: array
+      items:
+        $ref: "#/components/schemas/Box"
+
+    CredentialRequired:
+      description: >
+        Required fields of user credentials object.
+      type: object
+      required:
+        - password
+      properties:
+        password:
+          description: >
+            User password.
+          type: string
+
+    CredentialOptional:
+      description: >
+        Optional fields of user credentials object.
+      type: object
+      properties:
+        id:
+          description: >
+            Unique ID
+          type: integer
+          format: int64
+        protocol:
+          description: >
+            User authentication protocol to use.
+          type: string
+          enum: ['password']
+        user:
+          description: >
+            User name.
+          type: string
+        box:
+          type: object
+          description: >
+            Reference to simulated network device object.
+          properties:
+            name:
+              type: string
+            _links:
+              $ref: "#/components/schemas/Links"
+
+    Credential:
+      description: >
+        Fields of user credentials object.
+      allOf:
+        - $ref: "#/components/schemas/CredentialRequired"
+        - $ref: "#/components/schemas/CredentialOptional"
+
+    Credentials:
+      description: >
+        Collection of user credentials.
+      type: array
+      items:
+        $ref: "#/components/schemas/Credential"
+
+    PortRequired:
+      description: >
+        Required fields of network ports object.
+      type: object
+      properties:
+
+    PortOptional:
+      description: >
+        Optional fields of network ports object.
+      type: object
+      properties:
+        id:
+          description: >
+            Unique ID
+          type: integer
+          format: int64
+        name:
+          description: >
+            Port name.
+          type: string
+        description:
+          description: >
+            Port description.
+          type: string
+        shutdown:
+          description: >
+            Port is shut down.
+          type: boolean
+        speed:
+          description: >
+            Port maximum bit rate.
+          type: string
+          enum: ['10M', '1G', '10G']
+        auto_negotiation:
+          description: >
+            Port auto negotiation enabled.
+          type: boolean
+        mtu:
+          description: >
+            Port MTU.
+          type: integer
+        access_vlan:
+          type: object
+          description: >
+            Reference access VLAN port on top of this port.
+          properties:
+            name:
+              type: string
+            _links:
+              $ref: "#/components/schemas/Links"
+        trunk_vlans:
+          type: object
+          description: >
+            Reference trunk VLAN ports on top of this port.
+          properties:
+            name:
+              type: string
+            _links:
+              $ref: "#/components/schemas/Links"
+        trunk_native_vlan:
+          type: object
+          description: >
+            Reference trunk native VLAN port on top of this port.
+          properties:
+            name:
+              type: string
+            _links:
+              $ref: "#/components/schemas/Links"
+        box:
+          type: object
+          description: >
+            Reference to simulated network device object.
+          properties:
+            name:
+              type: string
+            _links:
+              $ref: "#/components/schemas/Links"
+
+    Port:
+      description: >
+        Ports object.
+      allOf:
+        - $ref: "#/components/schemas/PortRequired"
+        - $ref: "#/components/schemas/PortOptional"
+
+    Ports:
+      description: >
+        Collection of port objects.
+      type: array
+      items:
+        $ref: "#/components/schemas/Port"
+
+    VlanPortRequired:
+      description: >
+        Required fields of VLAN port object.
+      type: object
+      properties:
+        vlan_num:
+          description: >
+            VLAN ID of this port.
+          type: integer
+
+    VlanPortOptional:
+      description: >
+        Optional fields of VLAN port object.
+      type: object
+      properties:
+        id:
+          description: >
+            Unique ID
+          type: integer
+          format: int64
+        name:
+          description: >
+            VLAN port name.
+          type: string
+        description:
+          description: >
+            VLAN port description.
+          type: string
+        shutdown:
+          description: >
+            VLAN port is shut down.
+          type: boolean
+        mtu:
+          description: >
+            VLAN port MTU.
+          type: integer
+        access_group_in:
+          description: >
+            VLAN port access group inbound.
+          type: string
+        access_group_out:
+          description: >
+            VLAN port access group outbound.
+          type: string
+        ip_redirect:
+          description: >
+            VLAN port traffic redirect enabled.
+          type: boolean
+        ip_proxy_arp:
+          description: >
+            IP proxy ARP enabled on this VLAN port.
+          type: boolean
+        unicast_reverse_path_forwarding:
+          description: >
+            Unicast reverse path forwarding enabled on this VLAN port.
+          type: boolean
+        load_interval:
+          description: >
+            Load interval on this VLAN port.
+          type: integer
+        mpls_ip:
+          description: >
+            MPLS IP of this VLAN port.
+          type: string
+        port:
+          type: object
+          description: >
+            Reference to simulated network port on top of which this VLAN port
+            is created.
+          properties:
+            name:
+              type: string
+            _links:
+              $ref: "#/components/schemas/Links"
+
+    VlanPort:
+      description: >
+        VLAN port object.
+      allOf:
+        - $ref: "#/components/schemas/VlanPortRequired"
+        - $ref: "#/components/schemas/VlanPortOptional"
+
+    VlanPorts:
+      description: >
+        Collection of VLAN port objects.
+      type: array
+      items:
+        $ref: "#/components/schemas/VlanPort"
+
+    RouteRequired:
+      description: >
+        Required fields of network route object.
+      type: object
+      properties:
+        dst:
+          description: >
+            Route destination.
+          type: string
+        gw:
+          description: >
+            Network gateway.
+          type: string
+
+    RouteOptional:
+      description: >
+        Optional fields of network route object.
+      type: object
+      properties:
+        id:
+          description: >
+            Unique ID
+          type: integer
+          format: int64
+        metric:
+          description: >
+            Route metric.
+          type: integer
+        box:
+          type: object
+          description: >
+            Reference to simulated network device object.
+          properties:
+            name:
+              type: string
+            _links:
+              $ref: "#/components/schemas/Links"
+
+    Route:
+      description: >
+        Routes object.
+      allOf:
+        - $ref: "#/components/schemas/RouteRequired"
+        - $ref: "#/components/schemas/RouteOptional"
+
+    Routes:
+      description: >
+        Collection of route objects.
+      type: array
+      items:
+        $ref: "#/components/schemas/Route"
+
+    Links:
+      type: object
+      properties:
+        self:
+          description: >
+            URI pointing to the instance of one object in a collection
+          type: string
+        collection:
+          description: >
+            URI pointing to the entire collection of similar objects
+          type: string
+
+    Error:
+      type: object
+      required:
+        - status
+        - message
+      properties:
+        status:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-requests
+Flask-SQLAlchemy
+Flask<=1.1.1
+flask-marshmallow
 jinja2
+marshmallow
+marshmallow-sqlalchemy
+requests

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ params = {
     'packages': setuptools.find_packages(),
     'entry_points': {
         'console_scripts': [
-            'softboxen-cli = softboxen.cmd.cli:main'
+            'softboxen-cli = softboxen.cmd.cli:main',
+            'softboxen-restapi = softboxen.cmd.api:main',
         ]
     },
     'cmdclass': {

--- a/softboxen/api/__init__.py
+++ b/softboxen/api/__init__.py
@@ -1,0 +1,27 @@
+#
+# This file is part of softboxen software.
+#
+# Copyright (c) 2020, Ilya Etingof <etingof@gmail.com>
+# License: https://github.com/etingof/softboxen/LICENSE.rst
+#
+
+import os
+
+from flask import Flask
+from flask_marshmallow import Marshmallow
+from flask_sqlalchemy import SQLAlchemy
+
+from softboxen.api import config
+
+
+app = Flask(__name__)
+
+app.url_map.strict_slashes = False
+
+app.config.from_object(config.DefaultConfig)
+
+if 'SOFTBOXEN_CONFIG' in os.environ:
+    app.config.from_envvar('SOFTBOXEN_CONFIG')
+
+db = SQLAlchemy(app)
+ma = Marshmallow(app)

--- a/softboxen/api/config.py
+++ b/softboxen/api/config.py
@@ -1,0 +1,18 @@
+#
+# This file is part of softboxen software.
+#
+# Copyright (c) 2020, Ilya Etingof <etingof@gmail.com>
+# License: https://github.com/etingof/softboxen/LICENSE.rst
+#
+
+
+class DefaultConfig(object):
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory'
+    SQLALCHEMY_ECHO = False
+
+    DEBUG = False
+
+    SOFTBOXEN_MGMT_LISTEN_IP = '127.0.0.1'
+    SOFTBOXEN_MGMT_LISTEN_PORT = 5000
+    SOFTBOXEN_MGMT_SSL_CERT = None
+    SOFTBOXEN_MGMT_SSL_KEY = None

--- a/softboxen/api/models.py
+++ b/softboxen/api/models.py
@@ -1,0 +1,78 @@
+#
+# This file is part of softboxen software.
+#
+# Copyright (c) 2020, Ilya Etingof <etingof@gmail.com>
+# License: https://github.com/etingof/softboxen/LICENSE.rst
+#
+import uuid
+
+from softboxen.api import db
+
+
+class Box(db.Model):
+    id = db.Column(db.Integer(), primary_key=True)
+    vendor = db.Column(db.String(64), nullable=False)
+    model = db.Column(db.String(64), nullable=False)
+    version = db.Column(db.String(64), nullable=False)
+    uuid = db.Column(
+        db.String(36), nullable=False, unique=True,
+        default=lambda: str(uuid.uuid1()))
+    description = db.Column(db.String())
+    hostname = db.Column(db.String(64))
+    mgmt_address = db.Column(db.String(32))
+    credentials = db.relationship('Credential', backref='box', lazy='dynamic')
+    ports = db.relationship('Port', backref='box', lazy='dynamic')
+    vlan_ports = db.relationship('VlanPort', backref='box', lazy='dynamic')
+    routes = db.relationship('Route', backref='box', lazy='dynamic')
+
+
+class Credential(db.Model):
+    id = db.Column(db.Integer(), primary_key=True)
+    protocol = db.Column(
+        db.Enum('password'), nullable=False, default='password')
+    user = db.Column(db.String(64), nullable=True)
+    password = db.Column(db.String(32), nullable=True)
+    box_id = db.Column(db.Integer, db.ForeignKey('box.id'))
+
+
+class Port(db.Model):
+    id = db.Column(db.Integer(), primary_key=True)
+    name = db.Column(db.String(64))
+    description = db.Column(db.String())
+    shutdown = db.Column(db.Boolean(), default=False)
+    speed = db.Column(db.Enum('10M', '1G', '10G'), default='1G')
+    auto_negotiation = db.Column(db.Boolean(), default=True)
+    mtu = db.Column(db.Integer(), default=1500)
+    access_vlan = db.relationship(
+        'VlanPort', backref='access_on_port', lazy='dynamic')
+    trunk_vlans = db.relationship(
+        'VlanPort', backref='trunk_on_port', lazy='dynamic')
+    trunk_native_vlan = db.relationship(
+        'VlanPort', backref='trunk_native_on_port', lazy='dynamic')
+    box_id = db.Column(db.Integer, db.ForeignKey('box.id'))
+
+
+class VlanPort(db.Model):
+    id = db.Column(db.Integer(), primary_key=True)
+    vlan_num = db.Column(db.Integer(), nullable=False)
+    name = db.Column(db.String(64))
+    description = db.Column(db.String())
+    shutdown = db.Column(db.Boolean(), default=False)
+    mtu = db.Column(db.Integer(), default=1500)
+    access_group_in = db.Column(db.String(64))
+    access_group_out = db.Column(db.String(64))
+    ip_redirect = db.Column(db.Boolean(), default=False)
+    ip_proxy_arp = db.Column(db.Boolean(), default=False)
+    unicast_reverse_path_forwarding = db.Column(db.Boolean(), default=False)
+    load_interval = db.Column(db.Integer())
+    mpls_ip = db.Column(db.String(32))
+    port_id = db.Column(db.Integer, db.ForeignKey('port.id'))
+    box_id = db.Column(db.Integer, db.ForeignKey('box.id'))
+
+
+class Route(db.Model):
+    id = db.Column(db.Integer(), primary_key=True)
+    dst = db.Column(db.String(23))
+    gw = db.Column(db.String(23))
+    metric = db.Column(db.Integer(), default=1)
+    box_id = db.Column(db.Integer, db.ForeignKey('box.id'))

--- a/softboxen/api/schemas.py
+++ b/softboxen/api/schemas.py
@@ -1,0 +1,176 @@
+#
+# This file is part of softboxen software.
+#
+# Copyright (c) 2020, Ilya Etingof <etingof@gmail.com>
+# License: https://github.com/etingof/softboxen/LICENSE.rst
+#
+
+from softboxen.api import ma
+from softboxen.api import models
+
+
+class BoxSchema(ma.ModelSchema):
+    class Meta:
+        model = models.Box
+        fields = ('vendor', 'model', 'version', 'uuid', 'description',
+                  'hostname', 'mgmt_address', 'credentials',
+                  'ports', 'routes', '_links')
+
+    class CredentialSchema(ma.ModelSchema):
+        class Meta:
+            model = models.Credential
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor(
+                'show_credential', box_id='<box_id>', id='<id>'),
+             'collection': ma.URLFor('show_credentials', box_id='<box_id>')})
+
+    class PortSchema(ma.ModelSchema):
+        class Meta:
+            model = models.Port
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor('show_port', box_id='<box_id>', id='<id>'),
+             'collection': ma.URLFor('show_ports', box_id='<box_id>')})
+
+    class RouteSchema(ma.ModelSchema):
+        class Meta:
+            model = models.Route
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor('show_route', box_id='<box_id>', id='<id>'),
+             'collection': ma.URLFor('show_routes', box_id='<box_id>')})
+
+    _links = ma.Hyperlinks(
+        {'self': ma.URLFor('show_box', id='<id>'),
+         'collection': ma.URLFor('show_boxen')})
+
+    credentials = ma.Nested(CredentialSchema, many=True)
+    ports = ma.Nested(PortSchema, many=True)
+    routes = ma.Nested(RouteSchema, many=True)
+
+
+class CredentialSchema(ma.ModelSchema):
+    class Meta:
+        model = models.Credential
+        fields = ('protocol', 'credential', 'user', 'password',
+                  'box', '_links')
+
+    class BoxSchema(ma.ModelSchema):
+        class Meta:
+            model = models.Box
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor('show_box', id='<id>'),
+             'collection': ma.URLFor('show_boxen')})
+
+    _links = ma.Hyperlinks(
+        {'self': ma.URLFor('show_credential', box_id='<box_id>', id='<id>'),
+         'collection': ma.URLFor('show_credentials', box_id='<box_id>')})
+
+    box = ma.Nested(BoxSchema)
+
+
+class PortSchema(ma.ModelSchema):
+    class Meta:
+        model = models.Port
+        fields = ('name', 'description', 'shutdown', 'speed',
+                  'auto_negotiation', 'mtu', 'access_vlan',
+                  'trunk_vlans', 'trunk_native_vlan',
+                  'box', '_links')
+
+    class VlanSchema(ma.ModelSchema):
+        class Meta:
+            model = models.VlanPort
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor(
+                'show_vlan_port', box_id='<box_id>', port_id='<port_id>',
+                id='<id>'),
+             'collection': ma.URLFor(
+                'show_vlan_ports', box_id='<box_id>', port_id='<port_id>')})
+
+    class BoxSchema(ma.ModelSchema):
+        class Meta:
+            model = models.Box
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor('show_box', id='<id>'),
+             'collection': ma.URLFor('show_boxen')})
+
+    _links = ma.Hyperlinks(
+        {'self': ma.URLFor('show_port', box_id='<box_id>', id='<id>'),
+         'collection': ma.URLFor('show_ports', box_id='<box_id>')})
+
+    access_vlan = ma.Nested(VlanSchema, many=True)
+    trunk_vlans = ma.Nested(VlanSchema, many=True)
+    trunk_native_vlan = ma.Nested(VlanSchema, many=True)
+    box = ma.Nested(BoxSchema)
+
+
+class VlanPortSchema(ma.ModelSchema):
+    class Meta:
+        model = models.VlanPort
+        fields = ('vlan_num', 'name', 'description', 'shutdown', 'mtu',
+                  'access_group_in', 'access_group_out', 'ip_redirect',
+                  'ip_proxy_arp', 'unicast_reverse_path_forwarding',
+                  'load_interval', 'mpls_ip', 'access_on_port',
+                  'trunk_on_port', 'trunk_native_on_port', 'box',
+                  '_links')
+
+    class PortSchema(ma.ModelSchema):
+        class Meta:
+            model = models.Port
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor('show_port', box_id='<box_id>', id='<id>'),
+             'collection': ma.URLFor('show_ports', box_id='<box_id>')})
+
+    class BoxSchema(ma.ModelSchema):
+        class Meta:
+            model = models.Box
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor('show_box', id='<id>'),
+             'collection': ma.URLFor('show_boxen')})
+
+    _links = ma.Hyperlinks({
+        'self': ma.URLFor(
+            'show_vlan_port', box_id='<box_id>', port_id='<port_id>',
+            id='<id>'),
+        'collection': ma.URLFor(
+            'show_vlan_ports', box_id='<box_id>', port_id='<port_id>')})
+
+    access_on_port = ma.Nested(PortSchema)
+    trunk_on_port = ma.Nested(PortSchema)
+    trunk_native_on_port = ma.Nested(PortSchema)
+    box = ma.Nested(BoxSchema)
+
+
+class RouteSchema(ma.ModelSchema):
+    class Meta:
+        model = models.Credential
+        fields = ('dst', 'gw', 'metric', 'box', '_links')
+
+    class BoxSchema(ma.ModelSchema):
+        class Meta:
+            model = models.Box
+            fields = ('_links',)
+
+        _links = ma.Hyperlinks(
+            {'self': ma.URLFor('show_box', id='<id>'),
+             'collection': ma.URLFor('show_boxen')})
+
+    _links = ma.Hyperlinks(
+        {'self': ma.URLFor('show_route', box_id='<box_id>', id='<id>'),
+         'collection': ma.URLFor('show_routes', box_id='<box_id>')})
+
+    box = ma.Nested(BoxSchema)

--- a/softboxen/api/views.py
+++ b/softboxen/api/views.py
@@ -1,0 +1,355 @@
+#
+# This file is part of softboxen software.
+#
+# Copyright (c) 2020, Ilya Etingof <etingof@gmail.com>
+# License: https://github.com/etingof/softboxen/LICENSE.rst
+#
+
+import flask
+from sqlalchemy import func
+from werkzeug import exceptions
+
+from softboxen.api import app
+from softboxen.api import db
+from softboxen.api import models
+from softboxen.api import schemas
+
+PREFIX = '/softboxen/v1'
+
+
+@app.errorhandler(exceptions.HTTPException)
+def flask_exception_handler(exc):
+    app.logger.error(exc)
+    err = {
+        'status': exc.code,
+        'message': exc.description
+    }
+    response = flask.jsonify(err)
+    response.status_code = exc.code
+    return response
+
+
+@app.errorhandler(Exception)
+def all_exception_handler(exc):
+    app.logger.error(exc)
+    err = {
+        'status': 400,
+        'message': getattr(exc, 'message', str(exc))
+    }
+    response = flask.jsonify(err)
+    response.status_code = 400
+    return response
+
+
+def search_model(model, query):
+
+    known_columns = model.__table__.columns.keys()
+
+    for search_column in flask.request.args:
+        if search_column not in known_columns:
+            raise exceptions.NotFound(
+                'Search term %s is not supported' % search_column)
+
+        search_terms = flask.request.args.getlist(search_column)
+        if search_terms:
+            search_terms = [term.lower() for term in search_terms]
+            query = query.filter(
+                func.lower(getattr(model, search_column)).in_(search_terms))
+
+    return query
+
+
+@app.route(PREFIX + '/boxen')
+def show_boxen():
+    boxen_query = (
+        models.Box
+        .query)
+
+    boxen_query = search_model(models.Box, boxen_query)
+
+    schema = schemas.BoxSchema(many=True)
+    return schema.jsonify(boxen_query.all())
+
+
+@app.route(PREFIX + '/boxen/<id>', methods=['GET'])
+def show_box(id):
+    box = (
+        models.Box
+        .query
+        .filter_by(id=id)
+        .first())
+
+    if not box:
+        raise exceptions.NotFound('Box not found')
+
+    schema = schemas.BoxSchema()
+    return schema.jsonify(box), 200
+
+
+@app.route(PREFIX + '/boxen', methods=['POST'])
+def new_box():
+    req = flask.request.json
+
+    box = models.Box(**req)
+    db.session.add(box)
+
+    db.session.commit()
+
+    schema = schemas.BoxSchema()
+    return schema.jsonify(box), 201
+
+
+@app.route(PREFIX + '/boxen/<id>', methods=['DELETE'])
+def del_box(id):
+    box = (
+        models.Box
+        .query
+        .filter_by(id=id)
+        .first())
+
+    if not box:
+        raise exceptions.NotFound('Box not found')
+
+    db.session.delete(box)
+    db.session.commit()
+
+    return flask.Response(status=204)
+
+
+@app.route(PREFIX + '/boxen/<box_id>/credentials')
+def show_credentials(box_id):
+    credentials_query = (
+        models.Credential
+        .query
+        .filter_by(box_id=box_id))
+
+    credentials_query = search_model(models.Credential, credentials_query)
+
+    schema = schemas.CredentialSchema(many=True)
+    return schema.jsonify(credentials_query.all()), 200
+
+
+@app.route(PREFIX + '/boxen/<box_id>/credentials/<id>', methods=['GET'])
+def show_credential(box_id, id):
+    credential = (
+        models.Credential
+        .query
+        .filter_by(box_id=box_id, id=id)
+        .first())
+
+    if not credential:
+        raise exceptions.NotFound('Credentials not found')
+
+    schema = schemas.CredentialSchema()
+    return schema.jsonify(credential), 200
+
+
+@app.route(PREFIX + '/boxen/<box_id>/credentials', methods=['POST'])
+def new_credential(box_id):
+    req = flask.request.json
+
+    credential = models.Credential(box_id=box_id, **req)
+    db.session.add(credential)
+
+    db.session.commit()
+
+    schema = schemas.CredentialSchema()
+    return schema.jsonify(credential), 201
+
+
+@app.route(PREFIX + '/boxen/<box_id>/credentials/<id>', methods=['DELETE'])
+def del_credential(box_id, id):
+    credential = (
+        models.Credential
+        .query
+        .filter_by(box_id=box_id, id=id)
+        .first())
+
+    if not credential:
+        raise exceptions.NotFound('Credentials not found')
+
+    db.session.delete(credential)
+    db.session.commit()
+
+    return flask.Response(status=204)
+
+
+@app.route(PREFIX + '/boxen/<box_id>/ports')
+def show_ports(box_id):
+    ports_query = (
+        models.Port
+        .query
+        .filter_by(box_id=box_id))
+
+    ports_query = search_model(models.Port, ports_query)
+
+    schema = schemas.PortSchema(many=True)
+    return schema.jsonify(ports_query.all()), 200
+
+
+@app.route(PREFIX + '/boxen/<box_id>/ports/<id>', methods=['GET'])
+def show_port(box_id, id):
+    port = (
+        models.Port
+        .query
+        .filter_by(box_id=box_id, id=id)
+        .first())
+
+    if not port:
+        raise exceptions.NotFound('Port not found')
+
+    schema = schemas.PortSchema()
+    return schema.jsonify(port), 200
+
+
+@app.route(PREFIX + '/boxen/<box_id>/ports', methods=['POST'])
+def new_port(box_id):
+    req = flask.request.json
+
+    port = models.Port(box_id=box_id, **req)
+    db.session.add(port)
+
+    db.session.commit()
+
+    schema = schemas.PortSchema()
+    return schema.jsonify(port), 201
+
+
+@app.route(PREFIX + '/boxen/<box_id>/ports/<id>', methods=['DELETE'])
+def del_port(box_id, id):
+    port = (
+        models.Port
+        .query
+        .filter_by(box_id=box_id, id=id)
+        .first())
+
+    if not port:
+        raise exceptions.NotFound('Port not found')
+
+    db.session.delete(port)
+    db.session.commit()
+
+    return flask.Response(status=204)
+
+
+@app.route(PREFIX + '/boxen/<box_id>/ports/<port_id>/vlan_ports')
+def show_vlan_ports(box_id, port_id):
+    vlan_ports_query = (
+        models.VlanPort
+        .query
+        .filter_by(box_id=box_id, port_id=port_id))
+
+    vlan_ports_query = search_model(models.VlanPort, vlan_ports_query)
+
+    schema = schemas.VlanPortSchema(many=True)
+    return schema.jsonify(vlan_ports_query.all()), 200
+
+
+@app.route(
+    PREFIX + '/boxen/<box_id>/ports/<port_id>/vlan_ports/<id>',
+    methods=['GET'])
+def show_vlan_port(box_id, port_id, id):
+    vlan_port = (
+        models.VlanPort
+        .query
+        .filter_by(box_id=box_id, port_id=port_id, id=id)
+        .first())
+
+    if not vlan_port:
+        raise exceptions.NotFound('Vlan_ports not found')
+
+    schema = schemas.VlanPortSchema()
+    return schema.jsonify(vlan_port), 200
+
+
+@app.route(
+    PREFIX + '/boxen/<box_id>/ports/<port_id>/vlan_ports',
+    methods=['POST'])
+def new_vlan_port(box_id, port_id):
+    req = flask.request.json
+
+    vlan_port = models.VlanPort(
+        box_id=box_id, port_id=port_id, **req)
+    db.session.add(vlan_port)
+
+    db.session.commit()
+
+    schema = schemas.VlanPortSchema()
+    return schema.jsonify(vlan_port), 201
+
+
+@app.route(
+    PREFIX + '/boxen/<box_id>/ports/<port_id>/vlan_ports/<id>',
+    methods=['DELETE'])
+def del_vlan_port(box_id, port_id, id):
+    vlan_port = (
+        models.VlanPort
+        .query
+        .filter_by(box_id=box_id, port_id=port_id, id=id)
+        .first())
+
+    if not vlan_port:
+        raise exceptions.NotFound('VLAN port not found')
+
+    db.session.delete(vlan_port)
+    db.session.commit()
+
+    return flask.Response(status=204)
+
+
+@app.route(PREFIX + '/boxen/<box_id>/routes')
+def show_routes(box_id):
+    routes_query = (
+        models.Route
+        .query
+        .filter_by(box_id=box_id))
+
+    routes_query = search_model(models.Route, routes_query)
+
+    schema = schemas.RouteSchema(many=True)
+    return schema.jsonify(routes_query.all()), 200
+
+
+@app.route(PREFIX + '/boxen/<box_id>/routes/<id>', methods=['GET'])
+def show_route(box_id, id):
+    route = (
+        models.Route
+        .query
+        .filter_by(box_id=box_id, id=id)
+        .first())
+
+    if not route:
+        raise exceptions.NotFound('Routes not found')
+
+    schema = schemas.RouteSchema()
+    return schema.jsonify(route), 200
+
+
+@app.route(PREFIX + '/boxen/<box_id>/routes', methods=['POST'])
+def new_route(box_id):
+    req = flask.request.json
+
+    route = models.Route(box_id=box_id, **req)
+    db.session.add(route)
+
+    db.session.commit()
+
+    schema = schemas.RouteSchema()
+    return schema.jsonify(route), 201
+
+
+@app.route(PREFIX + '/boxen/<box_id>/routes/<id>', methods=['DELETE'])
+def del_route(box_id, id):
+    route = (
+        models.Route
+        .query
+        .filter_by(box_id=box_id, id=id)
+        .first())
+
+    if not route:
+        raise exceptions.NotFound('Routes not found')
+
+    db.session.delete(route)
+    db.session.commit()
+
+    return flask.Response(status=204)

--- a/softboxen/client/resources/box/vlan_port.py
+++ b/softboxen/client/resources/box/vlan_port.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 class VlanPort(base.Resource):
     """Represent VLAN port resource."""
 
-    vlan_id = base.Field('vlan_id')
+    vlan_num = base.Field('vlan_num')
     name = base.Field('name')
     description = base.Field('description')
     shutdown = base.Field('shutdown')

--- a/softboxen/cmd/api.py
+++ b/softboxen/cmd/api.py
@@ -1,0 +1,85 @@
+#
+# This file is part of softboxen software.
+#
+# Copyright (c) 2020, Ilya Etingof <etingof@gmail.com>
+# License: https://github.com/etingof/softboxen/LICENSE.rst
+#
+
+import argparse
+import os
+import sys
+
+from softboxen.api import app
+from softboxen.api import db
+from softboxen.api import views  # noqa
+
+DESCRIPTION = """\
+Softboxen CLI simulator REST API.
+
+Maintains network devices models in a persistent DB. Models
+can be created, removed or changed by REST API.
+
+Can be run as a WSGI application.
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+
+    parser.add_argument(
+        '--recreate-db',
+        action='store_true',
+        help='DANGER! Running with this flag wipes up REST API server DB! '
+             'This switch makes sense only when running this tool for the '
+             'first time.')
+
+    parser.add_argument(
+        '--config', type=str,
+        help='Config file path. Can also be set via environment variable '
+             'SOFTBOXEN_CONFIG.')
+
+    parser.add_argument(
+        '--interface', type=str,
+        help='IP address of the local interface for REST API'
+             'server to listen on. Can also be set via config variable '
+             'SOFTBOXEN_LISTEN_IP. Default is all local interfaces.')
+
+    parser.add_argument(
+        '--port', type=int,
+        help='TCP port to bind REST API server to.  Can also be '
+             'set via config variable SOFTBOXEN_LISTEN_PORT. '
+             'Default is 5000.')
+
+    return parser.parse_args()
+
+
+def main():
+
+    args = parse_args()
+
+    if args.config:
+        os.environ['SOFTBOXEN_CONFIG'] = args.config
+
+    config_file = os.environ.get('SOFTBOXEN_CONFIG')
+    if config_file:
+        app.config.from_pyfile(config_file)
+
+    if args.interface:
+        app.config['SOFTBOXEN_LISTEN_IP'] = args.interface
+
+    if args.port:
+        app.config['SOFTBOXEN_LISTEN_PORT'] = args.port
+
+    if args.recreate_db:
+        db.drop_all()
+        db.create_all()
+        return 0
+
+    app.run(host=app.config.get('SOFTBOXEN_LISTEN_IP'),
+            port=app.config.get('SOFTBOXEN_LISTEN_PORT'))
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/softboxen/exceptions.py
+++ b/softboxen/exceptions.py
@@ -87,6 +87,12 @@ class CommandSyntaxError(SoftboxenError):
         self.command = kwargs.get('command')
 
 
+class RestApiError(SoftboxenError):
+    """Raise on REST API error."""
+
+    message = 'REST API error: %(error)s'
+
+
 class HTTPError(SoftboxenError):
     """Raise on HTTP errors."""
 

--- a/tests/unit/client/resources/samples/vlan_port.json
+++ b/tests/unit/client/resources/samples/vlan_port.json
@@ -1,5 +1,5 @@
 {
-  "vlan_id": 10,
+  "vlan_num": 10,
   "name": "VLAN port",
   "description": "VLAN #1 access port",
   "port": {


### PR DESCRIPTION
This commit implements SQL-backed ORM models representing
simulated network devices. The models can be manipulated
over REST API server.

There are/will be two primary consumers of this REST API:

* CLI simulation processes reading and changing the
  properties of the models
* Admin tool that can create/remove classes of simulated
  devices, as well as instantiate them for simulaiton
  purposes.